### PR TITLE
Add in setPaddingLeft and setPaddingRight method

### DIFF
--- a/src/TextJustifyUtils.java
+++ b/src/TextJustifyUtils.java
@@ -1,4 +1,4 @@
-package customviews;
+package com.example.textjustify;
 
 import android.graphics.Paint;
 import android.view.Gravity;

--- a/src/TextViewEx.java
+++ b/src/TextViewEx.java
@@ -1,4 +1,6 @@
-package customviews;
+package com.example.textjustify;
+
+import com.fscz.util.TextJustifyUtils;
 
 import android.annotation.TargetApi;
 import android.content.Context;


### PR DESCRIPTION
When I tried TextviewEx, the words were sticked too close to the side of the screen. With this new commit, the text will be defaulty padded away from left and right side of the screen by 10 pixels each.
Users now are able to set their own padding value as well.
