### PR TITLE
Antialiasing established to Paint Object

### DIFF
--- a/src/TextViewEx.java
+++ b/src/TextViewEx.java
@@ -144,6 +144,7 @@ public class TextViewEx extends TextView
         paint.setTypeface(getTypeface());
         paint.setTextSize(getTextSize());
         paint.setTextAlign(_align);
+        paint.setFlags(Paint.ANTI_ALIAS_FLAG);
         
         //minus out the paddings pixel         
         dirtyRegionWidth = getWidth()-getPaddingLeft()-getPaddingRight();


### PR DESCRIPTION
Added paint.setFlags(Paint.ANTI_ALIAS_FLAG); on TextViewEx.java.

This helps to see letters betters.
If you don't set Antialising to On, the letters are horrible.

Kind Regards
