### PR TITLE
Avoid NPE when recycling

### DIFF
--- a/library/src/main/java/com/bluejamesbond/text/DocumentView.java
+++ b/library/src/main/java/com/bluejamesbond/text/DocumentView.java
@@ -854,8 +854,10 @@ public class DocumentView extends ScrollView {
                 drawCompleted = false;
             }
 
-            bitmap.recycle();
-            bitmap = null;
+            if (bitmap != null) {
+                bitmap.recycle();
+                bitmap = null;
+            }
         }
 
         public class CacheDrawTask extends AsyncTask<Void, Void, Void> {


### PR DESCRIPTION
I just got this exception from my app:

java.lang.NullPointerException
       at com.bluejamesbond.text.DocumentView$CacheBitmap.recycle(DocumentView.java:857)
       at com.bluejamesbond.text.DocumentView.destroyCache(DocumentView.java:672)
       at com.bluejamesbond.text.DocumentView.freeResources(DocumentView.java:662)
       at com.bluejamesbond.text.DocumentView.onDetachedFromWindow(DocumentView.java:509)
       at android.view.View.dispatchDetachedFromWindow(View.java:12787)
       at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:2706)