### PR TITLE
Fix max lines being exceeded

### DIFF
--- a/library/src/main/java/com/bluejamesbond/text/StringDocumentLayout.java
+++ b/library/src/main/java/com/bluejamesbond/text/StringDocumentLayout.java
@@ -191,7 +191,11 @@ public abstract class StringDocumentLayout extends IDocumentLayout {
                 // Next line
                 lineNumber++;
 
-                // Chcek cancelled
+                if (lineNumber >= params.maxLines) {
+                    break main;
+                }
+
+                // Check cancelled
                 if (cancelled.isCancelled()) {
                     done = false;
                     break;


### PR DESCRIPTION
The max lines check at line 104 isn't sufficient because multiple lines can be parsed in one go before the next check is conducted.