### PR TITLE
StringDocumentLayout text alignment fix

### DIFF
--- a/library/src/main/java/com/bluejamesbond/text/DocumentView.java
+++ b/library/src/main/java/com/bluejamesbond/text/DocumentView.java
@@ -296,6 +296,8 @@ public class DocumentView extends ScrollView {
                     layoutParams.setMaxLines(a.getInt(attr, layoutParams.getMaxLines()));
                 } else if (attr == R.styleable.DocumentView_documentView_lineHeightMultiplier) {
                     layoutParams.setLineHeightMultiplier(a.getFloat(attr, layoutParams.getLineHeightMultiplier()));
+                } else if (attr == R.styleable.DocumentView_documentView_lineSpacingExtra) {
+                    layoutParams.setLineSpacingExtra(a.getDimension(attr, layoutParams.getLineSpacingExtra()));
                 } else if (attr == R.styleable.DocumentView_documentView_textAlignment) {
                     layoutParams.setTextAlignment(TextAlignment.getById(a.getInt(attr, layoutParams.getTextAlignment().getId())));
                 } else if (attr == R.styleable.DocumentView_documentView_reverse) {
@@ -395,7 +397,7 @@ public class DocumentView extends ScrollView {
         }
     }
 
-    public View getViewportView(){
+    public View getViewportView() {
         return viewportView;
     }
 
@@ -473,7 +475,7 @@ public class DocumentView extends ScrollView {
                 viewportView.setMinimumHeight(layout.getMeasuredHeight());
                 measureState = MeasureTaskState.FINISH_AWAIT;
 
-                if(cacheConfig != CacheConfig.NO_CACHE){
+                if (cacheConfig != CacheConfig.NO_CACHE) {
                     allocateResources();
                 }
 

--- a/library/src/main/java/com/bluejamesbond/text/IDocumentLayout.java
+++ b/library/src/main/java/com/bluejamesbond/text/IDocumentLayout.java
@@ -70,6 +70,7 @@ public abstract class IDocumentLayout {
 
         params = new LayoutParams();
         params.setLineHeightMultiplier(1.0f);
+        params.setLineSpacingExtra(0.0f);
         params.setHyphenated(false);
         params.setReverse(false);
     }
@@ -185,32 +186,33 @@ public abstract class IDocumentLayout {
          * All the customizable parameters
          */
         protected IHyphenator hyphenator = null;
-        protected Float insetPaddingLeft = 0.0f;
-        protected Float insetPaddingTop = 0.0f;
-        protected Float insetPaddingBottom = 0.0f;
-        protected Float insetPaddingRight = 0.0f;
-        protected Float parentWidth = 800.0f;
-        protected Float offsetX = 0.0f;
-        protected Float offsetY = 0.0f;
+        protected float insetPaddingLeft = 0.0f;
+        protected float insetPaddingTop = 0.0f;
+        protected float insetPaddingBottom = 0.0f;
+        protected float insetPaddingRight = 0.0f;
+        protected float parentWidth = 800.0f;
+        protected float offsetX = 0.0f;
+        protected float offsetY = 0.0f;
 
-        protected Boolean debugging = false;
-        protected Float wordSpacingMultiplier = 1.0f;
-        protected Float lineHeightMultiplier = 0.0f;
-        protected Boolean hyphenated = false;
-        protected Boolean reverse = false;
-        protected Boolean subpixelText = false;
-        protected Boolean antialias = false;
-        protected Integer maxLines = Integer.MAX_VALUE;
+        protected boolean debugging = false;
+        protected float wordSpacingMultiplier = 1.0f;
+        protected float lineSpacingExtra = 0.0f;
+        protected float lineHeightMultiplier = 0.0f;
+        protected boolean hyphenated = false;
+        protected boolean reverse = false;
+        protected boolean subpixelText = false;
+        protected boolean antialias = false;
+        protected int maxLines = Integer.MAX_VALUE;
         protected String hyphen = "-";
         protected TextAlignment textAlignment = TextAlignment.LEFT;
 
-        protected Boolean textUnderline = false;
-        protected Boolean textStrikeThru = false;
-        protected Boolean textFakeBold = false;
+        protected boolean textUnderline = false;
+        protected boolean textStrikeThru = false;
+        protected boolean textFakeBold = false;
         protected Typeface textTypeface = Typeface.DEFAULT;
-        protected Float rawTextSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 14, displayMetrics);
-        protected Integer textColor = Color.BLACK;
-        protected Integer textLinkColor = Color.parseColor("#ff05c5cf");
+        protected float rawTextSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 14, displayMetrics);
+        protected int textColor = Color.BLACK;
+        protected int textLinkColor = Color.parseColor("#ff05c5cf");
 
         /**
          * If any settings have changed.
@@ -241,7 +243,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setWordSpacingMultiplier(float wordSpacingMultiplier) {
-            if (this.wordSpacingMultiplier.equals(wordSpacingMultiplier)) {
+            if (floatEquals(this.wordSpacingMultiplier, wordSpacingMultiplier)) {
                 return;
             }
 
@@ -284,7 +286,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setInsetPaddingLeft(float insetPaddingLeft) {
-            if (this.insetPaddingLeft.equals(insetPaddingLeft)) {
+            if (floatEquals(this.insetPaddingLeft, insetPaddingLeft)) {
                 return;
             }
 
@@ -297,7 +299,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setInsetPaddingTop(float insetPaddingTop) {
-            if (this.insetPaddingTop.equals(insetPaddingTop)) {
+            if (floatEquals(this.insetPaddingTop, insetPaddingTop)) {
                 return;
             }
 
@@ -310,7 +312,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setInsetPaddingBottom(float insetPaddingBottom) {
-            if (this.insetPaddingBottom.equals(insetPaddingBottom)) {
+            if (floatEquals(this.insetPaddingBottom, insetPaddingBottom)) {
                 return;
             }
 
@@ -323,7 +325,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setInsetPaddingRight(float insetPaddingRight) {
-            if (this.insetPaddingRight.equals(insetPaddingRight)) {
+            if (floatEquals(this.insetPaddingRight, insetPaddingRight)) {
                 return;
             }
 
@@ -336,7 +338,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setParentWidth(float parentWidth) {
-            if (this.parentWidth.equals(parentWidth)) {
+            if (floatEquals(this.parentWidth, parentWidth)) {
                 return;
             }
 
@@ -364,12 +366,25 @@ public abstract class IDocumentLayout {
             return lineHeightMultiplier;
         }
 
+        public float getLineSpacingExtra() {
+            return lineSpacingExtra;
+        }
+
         public void setLineHeightMultiplier(float lineHeightMultiplier) {
-            if (this.lineHeightMultiplier.equals(lineHeightMultiplier)) {
+            if (floatEquals(this.lineHeightMultiplier, lineHeightMultiplier)) {
                 return;
             }
 
             this.lineHeightMultiplier = lineHeightMultiplier;
+            invalidate();
+        }
+
+        public void setLineSpacingExtra(float lineSpacingExtra) {
+            if (floatEquals(this.lineSpacingExtra, lineSpacingExtra)) {
+                return;
+            }
+
+            this.lineSpacingExtra = lineSpacingExtra;
             invalidate();
         }
 
@@ -378,7 +393,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setHyphenated(boolean hyphenated) {
-            if (this.hyphenated.equals(hyphenated)) {
+            if (this.hyphenated == hyphenated) {
                 return;
             }
 
@@ -391,10 +406,9 @@ public abstract class IDocumentLayout {
         }
 
         public void setReverse(boolean reverse) {
-            if (this.reverse.equals(reverse)) {
+            if (this.reverse == reverse) {
                 return;
             }
-
 
             this.reverse = reverse;
             invalidate();
@@ -405,7 +419,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setMaxLines(int maxLines) {
-            if (this.maxLines.equals(maxLines)) {
+            if (this.maxLines == maxLines) {
                 return;
             }
 
@@ -440,7 +454,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setTextUnderline(boolean underline) {
-            if (this.textUnderline.equals(underline)) {
+            if (this.textUnderline == underline) {
                 return;
             }
 
@@ -453,7 +467,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setTextStrikeThru(boolean strikeThru) {
-            if (this.textStrikeThru.equals(strikeThru)) {
+            if (this.textStrikeThru == strikeThru) {
                 return;
             }
 
@@ -466,7 +480,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setTextFakeBold(boolean fakeBold) {
-            if (this.textFakeBold.equals(fakeBold)) {
+            if (this.textFakeBold == fakeBold) {
                 return;
             }
 
@@ -500,7 +514,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setRawTextSize(float textSize) {
-            if (this.rawTextSize.equals(textSize)) {
+            if (floatEquals(this.rawTextSize, textSize)) {
                 return;
             }
 
@@ -513,7 +527,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setTextColor(int textColor) {
-            if (this.textColor.equals(textColor)) {
+            if (this.textColor == textColor) {
                 return;
             }
 
@@ -526,7 +540,7 @@ public abstract class IDocumentLayout {
         }
 
         public void setDebugging(Boolean debugging) {
-            if (this.debugging.equals(debugging)) {
+            if (this.debugging == debugging) {
                 return;
             }
 
@@ -540,7 +554,7 @@ public abstract class IDocumentLayout {
 
         public void setTextSubPixel(boolean subpixelText) {
 
-            if (this.subpixelText.equals(subpixelText)) {
+            if (this.subpixelText == subpixelText) {
                 return;
             }
 
@@ -553,11 +567,17 @@ public abstract class IDocumentLayout {
 
         public void setAntialias(boolean antialias) {
 
-            if (this.antialias.equals(antialias)) {
+            if (this.antialias == antialias) {
                 return;
             }
 
             this.antialias = antialias;
         }
+
     }
+
+    private static boolean floatEquals(float a, float b) {
+        return Float.floatToIntBits(a) == Float.floatToIntBits(b);
+    }
+
 }

--- a/library/src/main/java/com/bluejamesbond/text/SpannableDocumentLayout.java
+++ b/library/src/main/java/com/bluejamesbond/text/SpannableDocumentLayout.java
@@ -161,7 +161,7 @@ public abstract class SpannableDocumentLayout extends IDocumentLayout {
         mLeadMarginSpanDrawEvents = new LinkedList<>();
 
         StaticLayout staticLayout = new StaticLayout(getText(), (TextPaint) getPaint(),
-                (int) boundWidth, Layout.Alignment.ALIGN_NORMAL, 1, 0, false);
+                (int) boundWidth, Layout.Alignment.ALIGN_NORMAL, params.getLineHeightMultiplier(), params.getLineSpacingExtra(), false);
         int[] newTokens = new int[TOKEN_LENGTH * 1000];
         LeadingMarginSpan[] activeLeadSpans = new LeadingMarginSpan[0];
         HashMap<LeadingMarginSpan, Integer> leadSpans = new HashMap<>();
@@ -179,7 +179,6 @@ public abstract class SpannableDocumentLayout extends IDocumentLayout {
         float y = params.insetPaddingTop;
         float left = params.insetPaddingLeft;
         float right = params.insetPaddingRight;
-        float lineHeightAdd = params.lineHeightMultiplier;
         float lastAscent;
         float lastDescent;
 
@@ -221,7 +220,7 @@ public abstract class SpannableDocumentLayout extends IDocumentLayout {
 
             // Calculate components of line height
             lastAscent = -staticLayout.getLineAscent(lineNumber);
-            lastDescent = staticLayout.getLineDescent(lineNumber) + lineHeightAdd;
+            lastDescent = staticLayout.getLineDescent(lineNumber);
 
             // Handle reverse
             DirectionSpan[] directionSpans = textCpy.getSpans(start, end, DirectionSpan.class);
@@ -467,7 +466,7 @@ public abstract class SpannableDocumentLayout extends IDocumentLayout {
         tokens = newTokens;
         params.changed = false;
         textChange = !done;
-        measuredHeight = (int) (y - lineHeightAdd + params.insetPaddingBottom);
+        measuredHeight = (int) (y + params.insetPaddingBottom);
 
         return done;
     }

--- a/library/src/main/java/com/bluejamesbond/text/StringDocumentLayout.java
+++ b/library/src/main/java/com/bluejamesbond/text/StringDocumentLayout.java
@@ -86,7 +86,7 @@ public abstract class StringDocumentLayout extends IDocumentLayout {
         // Get basic settings widget properties
         int lineNumber = 0;
         float width = params.parentWidth - params.insetPaddingRight - params.insetPaddingLeft;
-        float lineHeight = getTokenAscent(0) + getTokenDescent(0);
+        float lineHeight = getTokenAscent(0) + getTokenDescent(0) + params.lineSpacingExtra;
         float x, prog = 0, chunksLen = chunks.size();
         float y = params.insetPaddingTop + getTokenAscent(0);
         float spaceOffset = paint.measureText(" ") * params.wordSpacingMultiplier;
@@ -236,7 +236,7 @@ public abstract class StringDocumentLayout extends IDocumentLayout {
         lineCount = lineNumber;
         tokens = tokensArr;
         params.changed = !done;
-        measuredHeight = (int) (y - getTokenAscent(0) + params.insetPaddingBottom);
+        measuredHeight = (int) (y - getTokenAscent(0) + params.insetPaddingBottom - params.lineSpacingExtra);
         return done;
     }
 

--- a/library/src/main/java/com/bluejamesbond/text/StringDocumentLayout.java
+++ b/library/src/main/java/com/bluejamesbond/text/StringDocumentLayout.java
@@ -121,6 +121,18 @@ public abstract class StringDocumentLayout extends IDocumentLayout {
 
             // Line fits, then don't wrap
             if (wrappedWidth < width) {
+                float remainWidth = width - wrappedWidth;
+                switch (params.textAlignment) {
+                    case CENTER: {
+                        x += remainWidth / 2;
+                        break;
+                    }
+                    case RIGHT: {
+                        x += remainWidth;
+                        break;
+                    }
+                }
+
                 // activeCanvas.drawText(paragraph, x, y, paint);
                 tokensList.add(new SingleLine(lineNumber++, x, y, trimParagraph));
                 y += lineHeight;

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -41,6 +41,7 @@
         <attr name="documentView_offsetY" format="dimension"/>
         <attr name="documentView_wordSpacingMultiplier" format="float"/>
         <attr name="documentView_lineHeightMultiplier" format="float"/>
+		<attr name="documentView_lineSpacingExtra" format="dimension"/>
         <attr name="documentView_reverse" format="boolean"/>
         <attr name="documentView_maxLines" format="integer"/>
         <attr name="documentView_hyphen" format="string"/>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -129,6 +129,10 @@
             android:name="com.bluejamesbond.text.sample.test.ForceNoCacheXMLTest"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:theme="@android:style/Theme.NoTitleBar" />
+		<activity
+			android:name="com.bluejamesbond.text.sample.test.SingleWordTest"
+			android:configChanges="orientation|keyboardHidden|screenSize"
+			android:theme="@android:style/Theme.NoTitleBar" />
     </application>
 
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -133,6 +133,10 @@
 			android:name="com.bluejamesbond.text.sample.test.SingleWordTest"
 			android:configChanges="orientation|keyboardHidden|screenSize"
 			android:theme="@android:style/Theme.NoTitleBar" />
-    </application>
+		<activity
+			android:name="com.bluejamesbond.text.sample.test.LineSpacingTest"
+			android:configChanges="orientation|keyboardHidden|screenSize"
+			android:theme="@android:style/Theme.NoTitleBar" />
+	</application>
 
 </manifest>

--- a/sample/src/main/java/com/bluejamesbond/text/sample/helper/TestList.java
+++ b/sample/src/main/java/com/bluejamesbond/text/sample/helper/TestList.java
@@ -51,6 +51,7 @@ import com.bluejamesbond.text.sample.test.HyphenatedTest;
 import com.bluejamesbond.text.sample.test.ImageSpanTest;
 import com.bluejamesbond.text.sample.test.LeadingMarginSpan2Test;
 import com.bluejamesbond.text.sample.test.LineBreakTest;
+import com.bluejamesbond.text.sample.test.LineSpacingTest;
 import com.bluejamesbond.text.sample.test.ListViewTest;
 import com.bluejamesbond.text.sample.test.LongFormattedTextTest;
 import com.bluejamesbond.text.sample.test.LongPlainTextTest;
@@ -89,7 +90,8 @@ public class TestList extends TestActivity {
             ImageSpanTest.class,
             TextUpdateTest.class,
             ForceNoCacheXMLTest.class,
-            SingleWordTest.class
+            SingleWordTest.class,
+            LineSpacingTest.class
     };
 
     @Override

--- a/sample/src/main/java/com/bluejamesbond/text/sample/helper/TestList.java
+++ b/sample/src/main/java/com/bluejamesbond/text/sample/helper/TestList.java
@@ -59,6 +59,7 @@ import com.bluejamesbond.text.sample.test.NewLineTest;
 import com.bluejamesbond.text.sample.test.QuoteSpanTest;
 import com.bluejamesbond.text.sample.test.RTLTest;
 import com.bluejamesbond.text.sample.test.ShortFormattedTextTest;
+import com.bluejamesbond.text.sample.test.SingleWordTest;
 import com.bluejamesbond.text.sample.test.TextUpdateTest;
 import com.bluejamesbond.text.sample.test.TextViewTest;
 import com.bluejamesbond.text.sample.test.WordSpacingTest;
@@ -87,7 +88,8 @@ public class TestList extends TestActivity {
             ShortFormattedTextTest.class,
             ImageSpanTest.class,
             TextUpdateTest.class,
-            ForceNoCacheXMLTest.class
+            ForceNoCacheXMLTest.class,
+            SingleWordTest.class
     };
 
     @Override

--- a/sample/src/main/java/com/bluejamesbond/text/sample/test/LineSpacingTest.java
+++ b/sample/src/main/java/com/bluejamesbond/text/sample/test/LineSpacingTest.java
@@ -1,0 +1,24 @@
+package com.bluejamesbond.text.sample.test;
+
+import android.os.Bundle;
+
+import com.bluejamesbond.text.DocumentView;
+import com.bluejamesbond.text.sample.R;
+import com.bluejamesbond.text.sample.helper.TestActivity;
+
+public class LineSpacingTest extends TestActivity {
+
+    @Override protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        DocumentView documentView = addDocumentView("Document view now supports both String and Spannables. To support this, there are two (2) types of layouts: (a) " +
+                        "DocumentLayout and (b) SpannedDocumentLayout. " +
+                        "DocumentLayout supports just plain Strings just like the text you are reading. However, Spannables require the " +
+                        "constructor to have SpannedDocumentLayout.class as a parameter. For now, DocumentLayout will offer significant speed improvements " +
+                        "compared to SpannedDocumentLayout, so use each class accordingly. DocumentLayout also supports hyphenation. To learn more about" +
+                        "these layouts and what they have to offer visit the link in the titlebar above. And please report all the issues on GitHub!"
+                , DocumentView.PLAIN_TEXT);
+
+        documentView.getDocumentLayoutParams().setLineSpacingExtra(getResources().getDimension(R.dimen.line_spacing));
+    }
+
+}

--- a/sample/src/main/java/com/bluejamesbond/text/sample/test/SingleWordTest.java
+++ b/sample/src/main/java/com/bluejamesbond/text/sample/test/SingleWordTest.java
@@ -1,0 +1,18 @@
+package com.bluejamesbond.text.sample.test;
+
+import android.os.Bundle;
+
+import com.bluejamesbond.text.DocumentView;
+import com.bluejamesbond.text.sample.helper.TestActivity;
+import com.bluejamesbond.text.style.TextAlignment;
+
+
+public class SingleWordTest extends TestActivity {
+
+    @Override protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        DocumentView centerView = addDocumentView("Center", DocumentView.PLAIN_TEXT);
+        centerView.getDocumentLayoutParams().setTextAlignment(TextAlignment.CENTER);
+    }
+}

--- a/sample/src/main/res/values/dimens.xml
+++ b/sample/src/main/res/values/dimens.xml
@@ -31,5 +31,5 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
-
+	<dimen name="line_spacing">10sp</dimen>
 </resources>


### PR DESCRIPTION
`StringDocumentLayout` takes text alignment into account when fits line without wrapping.