### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,31 @@
 
 **Android Full Justification** 
 
-#About
+# About
 This library will provide you a way to justify text. It supports both plain text and Spannables. Additionally, the library can auto-hyphentate your displayed content (thanks to [@muriloandrade](https://github.com/muriloandrade)).
 
 *Compatible for Android 2.2 to 5.X*
 
-#Other Libraries
+# Other Libraries
 - [FacebookMessengerBot.js](https://github.com/bluejamesbond/FacebookMessengerBot.js) - a Node ES5/6 API for the new Facebook Messenger Bot Platform
 - [Scribe.js](https://github.com/bluejamesbond/Scribe.js) - a Node ES5/6 logging system with a web interface
  
-#Screenshot
+# Screenshot
 ![Preview](http://i.imgur.com/k6bAWd0.jpg)
 
-#Demo
+# Demo
 [![Imgur](http://i.imgur.com/hSGF1fV.png)](https://play.google.com/store/apps/details?id=com.bluejamesbond.text.sample)
 
-#Recent
+# Recent
 **01/11/2015** ► Added support for very long documents with fading and progress listener  
 **01/10/2015** ► Refractored / renamed classes  
 **01/04/2015** ► Improved caching support which allows for smooth scrolling  
 **01/02/2015** ► Added XML attributes for `DocumentView`
 
-#Wiki
+# Wiki
 For examples, tests, and API refer to the [Android-TextJustify Wiki](https://github.com/bluejamesbond/TextJustify-Android/wiki/1-%C2%B7-Home).
 
-#Install
+# Install
 Just add to your `build.gradle`
 ```gradle
 dependencies {
@@ -36,7 +36,7 @@ dependencies {
 }
 ```
 
-#Known Issues
+# Known Issues
 | Status| Issues    |
 | :------------:    |:---------------|
 |  **`CLOSED`**     | Scroll caching for very large documents i.e. > 4000 paragaphs |


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
