### PR TITLE
StringDocumentLayout text alignment fix

### DIFF
--- a/library/src/main/java/com/bluejamesbond/text/StringDocumentLayout.java
+++ b/library/src/main/java/com/bluejamesbond/text/StringDocumentLayout.java
@@ -121,6 +121,18 @@ public abstract class StringDocumentLayout extends IDocumentLayout {
 
             // Line fits, then don't wrap
             if (wrappedWidth < width) {
+                float remainWidth = width - wrappedWidth;
+                switch (params.textAlignment) {
+                    case CENTER: {
+                        x += remainWidth / 2;
+                        break;
+                    }
+                    case RIGHT: {
+                        x += remainWidth;
+                        break;
+                    }
+                }
+
                 // activeCanvas.drawText(paragraph, x, y, paint);
                 tokensList.add(new SingleLine(lineNumber++, x, y, trimParagraph));
                 y += lineHeight;

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -129,6 +129,10 @@
             android:name="com.bluejamesbond.text.sample.test.ForceNoCacheXMLTest"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:theme="@android:style/Theme.NoTitleBar" />
+		<activity
+			android:name="com.bluejamesbond.text.sample.test.SingleWordTest"
+			android:configChanges="orientation|keyboardHidden|screenSize"
+			android:theme="@android:style/Theme.NoTitleBar" />
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/bluejamesbond/text/sample/helper/TestList.java
+++ b/sample/src/main/java/com/bluejamesbond/text/sample/helper/TestList.java
@@ -59,6 +59,7 @@ import com.bluejamesbond.text.sample.test.NewLineTest;
 import com.bluejamesbond.text.sample.test.QuoteSpanTest;
 import com.bluejamesbond.text.sample.test.RTLTest;
 import com.bluejamesbond.text.sample.test.ShortFormattedTextTest;
+import com.bluejamesbond.text.sample.test.SingleWordTest;
 import com.bluejamesbond.text.sample.test.TextUpdateTest;
 import com.bluejamesbond.text.sample.test.TextViewTest;
 import com.bluejamesbond.text.sample.test.WordSpacingTest;
@@ -87,7 +88,8 @@ public class TestList extends TestActivity {
             ShortFormattedTextTest.class,
             ImageSpanTest.class,
             TextUpdateTest.class,
-            ForceNoCacheXMLTest.class
+            ForceNoCacheXMLTest.class,
+            SingleWordTest.class
     };
 
     @Override

--- a/sample/src/main/java/com/bluejamesbond/text/sample/test/SingleWordTest.java
+++ b/sample/src/main/java/com/bluejamesbond/text/sample/test/SingleWordTest.java
@@ -1,0 +1,18 @@
+package com.bluejamesbond.text.sample.test;
+
+import android.os.Bundle;
+
+import com.bluejamesbond.text.DocumentView;
+import com.bluejamesbond.text.sample.helper.TestActivity;
+import com.bluejamesbond.text.style.TextAlignment;
+
+
+public class SingleWordTest extends TestActivity {
+
+    @Override protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        DocumentView centerView = addDocumentView("Center", DocumentView.PLAIN_TEXT);
+        centerView.getDocumentLayoutParams().setTextAlignment(TextAlignment.CENTER);
+    }
+}


### PR DESCRIPTION
`StringDocumentLayout` takes text alignment into account when fits line without wrapping.

**Before:**
![device-2017-04-27-162930](https://cloud.githubusercontent.com/assets/183590/25485676/6258827e-2b67-11e7-99f4-98cd1b7ece08.png)

**After:**
![device-2017-04-27-162956](https://cloud.githubusercontent.com/assets/183590/25485677/625dfb14-2b67-11e7-9844-e1046baf5cc3.png)

